### PR TITLE
Move install to inside entrypoint

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -11,11 +11,8 @@ RUN npm run build
 
 
 FROM base AS development
-COPY package*.json ./
-RUN npm install
-COPY . .
 EXPOSE 3000
-CMD ["npm", "run", "dev"]
+ENTRYPOINT ["/var/c3d/backend/container/entrypoint.sh"]
 
 
 FROM base AS final

--- a/backend/container/entrypoint.sh
+++ b/backend/container/entrypoint.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+cd /var/c3d/backend || exit
+npm install
+npm run dev


### PR DESCRIPTION
docker-compose will mount over the container contents so we have to install after. Since development is only for the compose setup we don't need to spend time installing stuff in the docker build for development.